### PR TITLE
downgrade required python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 description = "A collection of Python utility functions by Tenhil GmbH & Co. KG"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
seems like we're not using python-3.11-specific features in the code, so it's just a formal change