### PR TITLE
allow sql logging for non-default django databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
 
 - add CdnBulkStaticStorage class to django package
 
-
 ## 1.3.1
 
 - add utility management commands for s3 utils
+
+## 1.5.1
+
+- change the use of Django's `connection.execute_wrapper` to `connections[db_name].execute_wrapper` for SQL logging on
+  non-default dbs

--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ SELECT COUNT(*) AS "__count" FROM "myapp_author"; args=(); alias=default
 - `truncate_unparsable`: Boolean, default `True`. If a query gets too long to be parsed in reasonable time (for formatting and syntax highlights), we
   will just trim it and display it the default way. So no formatting or colors. But if you really want to see the whole query, you can force that.
 
+
+- `db_name`: String to specify the database to work with when you have a multiple database setup or when you don't have the `default` alias for your DB.
+    Default value is `default`. 
+
+
 In this example, the SQL is indented, and the arguments are limited to 5:
 
 ```sql

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baumbelt"
-version = "1.5.0"
+version = "1.5.1"
 authors = [
     { name = "Watte", email = "python@tenhil.de" },
 ]

--- a/src/baumbelt/django/sql/query_logging.py
+++ b/src/baumbelt/django/sql/query_logging.py
@@ -4,7 +4,7 @@ import time
 import pygments
 import sqlparse
 from django.core.management.color import supports_color
-from django.db import connection
+from django.db import connections
 from pygments.formatters.terminal import TerminalFormatter
 from pygments.lexers import SqlLexer
 from sqlparse.sql import Parenthesis, IdentifierList, Identifier
@@ -116,7 +116,12 @@ class DjangoSQLWrapper:
 
 
 @contextlib.contextmanager
-def django_sql_debug(indent: bool = False, max_arguments: int = 5, truncate_unparsable: bool = True):
+def django_sql_debug(
+        indent: bool = False,
+        max_arguments: int = 5,
+        truncate_unparsable: bool = True,
+        db_name: str = "default"
+):
     dj_sql_wrap = DjangoSQLWrapper(indent=indent, max_arguments=max_arguments, truncate_unparsable=truncate_unparsable)
-    with connection.execute_wrapper(dj_sql_wrap):
+    with connections[db_name].execute_wrapper(dj_sql_wrap):
         yield


### PR DESCRIPTION
This will add `db_name` to the arguments of `django_sql_debug` and change the function to use `connections[db_name]` instead of `connection`. This will allow `execute_wrapper` to work with all dbs in a multiple db setup.