### PR TITLE
smart-retry: add __str__ of OverallTimeout for nicer errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install pytest
+      - name: Install dependencies
         run: |
+          python -m pip install -e .
           python -m pip install pytest
 
       - name: Unit tests

--- a/src/baumbelt/requests.py
+++ b/src/baumbelt/requests.py
@@ -2,14 +2,20 @@ import logging
 from datetime import datetime, timedelta
 from time import sleep
 
-from requests import Timeout, Response
-from requests.adapters import HTTPAdapter, DEFAULT_POOLSIZE, DEFAULT_POOLBLOCK
+from requests import Response, Timeout
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, HTTPAdapter
 
 logger = logging.getLogger(__name__)
 
 
 class OverallTimeout(Timeout):
-    pass
+    def __init__(self, attempts: int = 0, url: str = "", **kwargs):
+        super().__init__(**kwargs)
+        self.attempts = attempts
+        self.url = url
+
+    def __str__(self):
+        return f"OverallTimeout(attempts={self.attempts},url={self.url})"
 
 
 class SmartRetryHTTPAdapter(HTTPAdapter):
@@ -112,4 +118,4 @@ class SmartRetryHTTPAdapter(HTTPAdapter):
             response.raise_for_status()
             return response
 
-        raise last_error or OverallTimeout(request=request)
+        raise last_error or OverallTimeout(attempts=attempts, url=request.url)

--- a/tests/test_smart_http_retry.py
+++ b/tests/test_smart_http_retry.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from baumbelt.requests import OverallTimeout
+
+
+class OverallTimeoutStrTestCase(TestCase):
+    def test_str_includes_attempts_and_url(self):
+        err = OverallTimeout(attempts=3, url="api.example.com/v1/resource?foo=bar")
+        self.assertEqual(str(err), "OverallTimeout(attempts=3,url=api.example.com/v1/resource?foo=bar)")


### PR DESCRIPTION
So logged OverallTimeout errors become more like:

> "OverallTimeout(attempts=5,url=service.internal:8000/v1/resource)"

And less like:

> "OverallTimeout"